### PR TITLE
Add Standards and Virtual Power Plants documentation

### DIFF
--- a/docs/platform-concepts/standards.md
+++ b/docs/platform-concepts/standards.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 12
+---
+
+# Standards
+
+Texture supports industry-standard protocols for device communication and demand response, enabling seamless integration with a wide range of energy systems and market participants.
+
+## Supported Standards
+
+### IEEE 2030.5
+
+**IEEE 2030.5** (formerly known as Smart Energy Profile 2.0) is a communication protocol for energy management that enables utilities, service providers, and customers to exchange information about energy usage and coordinate control of devices on the smart grid.
+
+Key features of IEEE 2030.5:
+- **Secure Communications**: Implements robust security mechanisms for device communication
+- **Device Discovery**: Enables automatic device discovery and registration
+- **Demand Response**: Supports demand response event messaging and participation
+- **Distributed Energy Resources (DER)**: Provides capabilities for managing solar, storage, and other DERs
+- **Metering**: Allows exchange of energy usage data
+
+Texture supports IEEE 2030.5 specifically for device telemetry and control operations. This enables you to monitor and manage compatible devices through a standardized protocol while leveraging Texture's platform capabilities for analytics, automation, and integration.
+
+### OpenADR 3.0
+
+**OpenADR** (Open Automated Demand Response) is a standardized way for electricity providers and system operators to communicate demand response signals with each other and with their customers using a common language.
+
+OpenADR 3.0 builds upon earlier versions with:
+- **Enhanced Security**: Improved authentication and encryption mechanisms
+- **Increased Flexibility**: More granular control and reporting capabilities
+- **Broader Application**: Support for diverse grid services beyond traditional demand response
+- **Improved Performance**: Optimized for higher volume and frequency of messages
+
+Texture supports OpenADR 3.0 for controlling demand response participation, allowing you to seamlessly integrate with utility programs and grid services while maintaining visibility and control through the Texture platform.
+
+## Implementation Notes
+
+- We currently do not support OpenADR 2.x versions, though we welcome feedback if you have specific requirements for these older protocol versions.
+- Implementation of these standards typically requires a bespoke setup depending on the specific devices being controlled and the systems they interface with.
+- Our team works directly with customers to configure and validate the appropriate integration approach for each use case.
+- Both standards can be used simultaneously within the same deployment for different aspects of your energy management strategy.
+
+## Getting Started with Standards
+
+If you're interested in leveraging IEEE 2030.5 or OpenADR 3.0 capabilities within your Texture implementation, please use the live chat feature in the Dashboard (look for the chat bubble in the lower right corner) to connect with our team. We'll work with you to understand your requirements and design an appropriate implementation plan.

--- a/docs/platform-concepts/virtual-power-plants.md
+++ b/docs/platform-concepts/virtual-power-plants.md
@@ -1,0 +1,62 @@
+---
+sidebar_position: 13
+---
+
+# Virtual Power Plants
+
+## What is a Virtual Power Plant (VPP)?
+
+A **Virtual Power Plant (VPP)** is a network of decentralized, medium-scale power generating units, flexible power consumers, and storage systems that are aggregated and operated as a single entity. Unlike traditional power plants, VPPs are distributed across multiple locations but can be remotely and collectively controlled.
+
+VPPs typically include:
+- **Distributed Energy Resources (DERs)** such as solar panels and wind turbines
+- **Energy Storage Systems** like batteries
+- **Flexible Loads** that can adjust their energy consumption on demand
+- **Electric Vehicles** and their charging infrastructure
+
+By intelligently coordinating these diverse assets, VPPs can:
+- Provide grid services like frequency regulation and peak shaving
+- Participate in energy markets and demand response programs
+- Optimize energy usage and generation based on price signals
+- Enhance grid resilience and stability
+
+## VPPs on Texture
+
+Many VPP operators build and run their networks on the Texture platform, leveraging our device control capabilities, real-time data processing, and extensive integration options.
+
+### Core VPP Capabilities
+
+Texture provides the following capabilities essential for VPP operations:
+
+1. **Device Connectivity**: Direct integration with a wide range of energy assets, including solar inverters, battery systems, EV chargers, and smart thermostats
+2. **Real-Time Control**: Secure, reliable command dispatch to individual devices or groups of devices
+3. **Telemetry**: Continuous monitoring of device status, power output, and energy consumption
+4. **Aggregation**: Logical grouping of devices by location, type, or other criteria for coordinated control
+5. **Automation**: Rule-based and algorithmic control based on time, price signals, or other triggers
+6. **Visibility**: Comprehensive dashboards and reporting for monitoring VPP performance
+
+### Market Access and Program Management
+
+While Texture provides the foundational technology for operating VPPs, many operators also need specialized capabilities for market access and program management. For these needs, Texture integrates with specialized partners:
+
+#### Leap Energy Integration
+
+Through the [Leap Energy](./apps.md#leap) App, VPP operators can:
+- Access multiple demand response programs and energy markets
+- Receive dispatches and automatically translate them to device commands
+- Submit enrollment information and track participation
+- Handle settlements and performance reporting
+
+#### Shadow Power Integration
+
+The [Shadow Power](./apps.md#shadow-power) App enables VPP operators to:
+- Monetize behind-the-meter flexibility
+- Access wholesale energy markets
+- Optimize asset dispatch based on market conditions
+- Manage financial settlements
+
+### Getting Started with VPPs on Texture
+
+Whether you're looking to build a new VPP or migrate an existing one to a more robust platform, Texture provides the technology foundation you need.
+
+To discuss your specific VPP requirements, use the live chat feature in the Dashboard (look for the chat bubble in the lower right corner) to connect with our team.


### PR DESCRIPTION
## Summary
- Add new Standards page in Platform Concepts documenting:
  - IEEE 2030.5 support for telemetry and device control
  - OpenADR 3.0 support for controlling demand response participation
  - Implementation notes including that OpenADR 2.x is not currently supported
  - Information about bespoke setup requirements
- Create Virtual Power Plants (VPP) page explaining:
  - What VPPs are and their components (DERs, storage, flexible loads, EVs)
  - How VPPs operate on the Texture platform
  - Market access options through Leap Energy and Shadow Power Apps
  - Getting started guidance for VPP operators

## Test plan
- Verified both pages build correctly
- Ensured consistent formatting with other platform concept pages
- Confirmed accurate cross-references to Apps and other relevant sections
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added new documentation pages for Standards and Virtual Power Plants (VPPs) to explain supported protocols and VPP operations on the Texture platform.

- **New Features**
  - Standards page covers IEEE 2030.5 and OpenADR 3.0 support, implementation notes, and setup guidance.
  - VPP page explains VPP concepts, core platform capabilities, market access via Leap Energy and Shadow Power, and getting started steps.

<!-- End of auto-generated description by mrge. -->

