### PR TITLE
Update supported devices docs with blog post reference

### DIFF
--- a/docs/sources/supported-devices.mdx
+++ b/docs/sources/supported-devices.mdx
@@ -16,11 +16,13 @@ platform, please [let us know](https://www.texturehq.com/contact-us).
 
 **We never use web scraping or reverse engineering in any of our device integrations.**
 
-We work directly with manufacturers or partners to get access to the well supported APIs for their devices. In most cases we have direct lines of communication and support channels as well as targeted SLAs.
+We work directly with manufacturers or partners to build OEM Partnership APIs with well-documented access to device capabilities. These partnerships include contractual SLAs and dedicated communication channels for support.
 
-We believe this is the best way to ensure the quality of the data and reliability of the Texture platform. Some other companies may use web scraping or reverse engineering to get access to device data rather than relying on the official APIs.We believe this is not only unethical, but also leads to a poor experience for customers and manufacturers.
+Reverse-engineered APIs are unstable, undocumented, and prone to break at any time. They create high maintenance overhead, introduce major security and compliance risks (often requiring storage of sensitive user credentials), and are limited to only what a user could do in an app's interface.
 
-No serious company can make a business case to have their business reliant on web scraping or reverse engineering.
+Our approach ensures the reliability, security, and long-term viability of our platform. This strategic decision enables more sophisticated integrations and provides an enterprise-grade foundation for the entire energy ecosystem.
+
+For a more detailed explanation of why we take this approach, read our blog post: [Why Texture Doesn't Reverse Engineer APIs and Why That Matters](https://www.texturehq.com/blog/why-texture-doesnt-reverse-engineer-apis-and-why-that-matters).
 
 ## Our vision
 


### PR DESCRIPTION
## Summary
- Updates the 'A note on our integration quality' section to align with the blog post language
- Adds a reference to the blog post 'Why Texture Doesn't Reverse Engineer APIs and Why That Matters'
- Enhances explanation of why reverse-engineered APIs are problematic
- Highlights Texture's strategic approach to OEM partnerships