### PR TITLE
Fix: Hide supported-devices from sidebar menu

### DIFF
--- a/docs/sources/supported-devices.mdx
+++ b/docs/sources/supported-devices.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+sidebar_class_name: hidden
 ---
 
 import React, { useEffect } from 'react';

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -133,6 +133,10 @@ nav.menu, .navbar-sidebar {
 .menu__link--active:not(.menu__link--sublist) {
   background: none;
 }
+/* Hide items with hidden class */
+.hidden {
+  display: none !important;
+}
 @media (min-width: 997px) {
   @supports (scrollbar-gutter: stable) {
     .menu_node_modules-\@docusaurus-theme-classic-lib-theme-DocSidebar-Desktop-Content-styles-module {


### PR DESCRIPTION
## Summary
- Adds `sidebar_class_name: hidden` to supported-devices.mdx front matter
- Adds `.hidden { display: none \!important; }` CSS rule to hide sidebar items
- Preserves redirect functionality for direct URL access

🤖 Generated with [Claude Code](https://claude.ai/code)