### PR TITLE
Remove GitHub private registry requirement

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,7 +1,1 @@
 nodeLinker: node-modules
-npmScopes:
-  texturehq:
-    npmRegistryServer: "https://npm.pkg.github.com"
-npmRegistries:
-  "//npm.pkg.github.com":
-    npmAuthToken: ${GITHUB_TOKEN}


### PR DESCRIPTION
## Summary
This PR removes the GitHub private registry configuration, making the repository truly open source and accessible to external contributors.

## Changes
- Removed `npmScopes` and `npmRegistries` configuration from `.yarnrc.yml`
- No longer requires `GITHUB_TOKEN` environment variable for package installation
- External contributors can now clone and run `yarn install` without authentication

## Why this change?
- `@texturehq/events` is now publicly available on npm
- Enables external contributions to the open source project
- Removes unnecessary authentication barrier

## Testing
- Verified `yarn install` works without `GITHUB_TOKEN` set
- All dependencies install correctly from public npm registry

🤖 Generated with [Claude Code](https://claude.ai/code)