### PR TITLE
Add Kafka destination docs

### DIFF
--- a/docs/destinations/event-types.mdx
+++ b/docs/destinations/event-types.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: Event Types
 ---
 

--- a/docs/destinations/kafka.md
+++ b/docs/destinations/kafka.md
@@ -1,0 +1,23 @@
+---
+sidebar_position: 5
+title: Kafka
+---
+
+## Overview
+Kafka destinations let you push any events from your workspace directly to a Kafka topic. When you create a Kafka destination you provide:
+
+- **Label** – a name for the destination
+- **Device type** – optional filter to only send events for certain device types
+- **Brokers** – comma separated list of brokers for your cluster
+- **Client ID** – unique identifier for this Kafka client
+- **Topic** – the Kafka topic to publish events to
+
+Texture supports both SSL and SASL connections. For SASL you can choose `plain`, `scram-sha-256` or `scram-sha-512` authentication and supply a username and password. If you select `none`, no authentication is used.
+
+There are no restrictions on event types for Kafka destinations; all events from your workspace can be forwarded to your Kafka cluster.
+
+## Use cases
+
+* **Real‑time processing** – feed events into your own streaming pipelines
+* **Data warehousing** – ship events to your data lake via Kafka connectors
+

--- a/docs/destinations/overview.md
+++ b/docs/destinations/overview.md
@@ -21,13 +21,13 @@ Currently supported destinations:
 - [Webhooks](./webhooks.md)
 - [Email](./email.md)
 - [SMS](./sms.md)
+- [Kafka](./kafka.md)
 
 **Coming soon**
 
 - s3
 - WebSocket
 - MQTT
-- Kafka
 - Push Notifications
 - Snowflake
 - Databricks


### PR DESCRIPTION
## Summary
- document the Kafka destination
- move Kafka from coming-soon list to active
- bump Event Types sidebar order

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_68541e6bd50083278069a99f6e66bd1c
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added documentation for the Kafka destination, including setup details and use cases. Kafka is now listed as an active destination instead of coming soon.

<!-- End of auto-generated description by cubic. -->

